### PR TITLE
Add Cancel command and update layouts in AddBookPage

### DIFF
--- a/ViewModels/Books/AddBookViewModel.cs
+++ b/ViewModels/Books/AddBookViewModel.cs
@@ -89,6 +89,12 @@ public partial class AddBookViewModel : ObservableObject
 
     }
 
+    [RelayCommand]
+    private async Task Cancel()
+    {
+        await Shell.Current.GoToAsync("..");
+    }
+
     public void OnNavigatedTo()
     {
         ResetFields();

--- a/Views/Books/AddBookPage.xaml
+++ b/Views/Books/AddBookPage.xaml
@@ -6,26 +6,43 @@
     xmlns:viewmodel="clr-namespace:MyApp.ViewModels"
     Title="Add Book"
     x:DataType="viewmodel:AddBookViewModel">
-    <VerticalStackLayout Margin="20">
-        <Entry Placeholder="Title" Text="{Binding BookTitle}" />
-        <Entry Placeholder="Author" Text="{Binding BookAuthor}" />
-        <HorizontalStackLayout>
-            <CheckBox IsChecked="{Binding BookIsFinished}" />
-            <Label Text="Have you finished reading this book?" VerticalOptions="Center" />
-        </HorizontalStackLayout>
-        <Button
-            Text="Select File"
-            Command="{Binding SelectFileCommand}" />
-        <!-- Image preview -->
-        <Image
-            Source="{Binding ImageUrl}"
-            Aspect="AspectFit"
-            HeightRequest="150"
-            IsVisible="{Binding ImageUrl, Converter={StaticResource NullToBoolConverter}}" />
-        <Button
-            Background="#3ece8e"
-            Command="{Binding AddBookCommand}"
-            Text="Add Book"
-            TextColor="#eff5f3" />
-    </VerticalStackLayout>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <VerticalStackLayout Margin="20" Grid.Row="0">
+            <Entry Placeholder="Title" Text="{Binding BookTitle}" />
+            <Entry Placeholder="Author" Text="{Binding BookAuthor}" />
+            <HorizontalStackLayout>
+                <CheckBox IsChecked="{Binding BookIsFinished}" />
+                <Label Text="Have you finished reading this book?" VerticalOptions="Center" />
+            </HorizontalStackLayout>
+            <Button
+                Margin="0,0,0,10"
+                Text="Select File"
+                Command="{Binding SelectFileCommand}" />
+            <!-- Image preview -->
+            <Image
+                Source="{Binding ImageUrl}"
+                Aspect="AspectFit"
+                MaximumHeightRequest="300"
+                WidthRequest="{Binding Source={x:Reference ContentPage}, Path=Width}"
+                IsVisible="{Binding ImageUrl, Converter={StaticResource NullToBoolConverter}}" />
+        </VerticalStackLayout>
+        <Grid HeightRequest="80" Grid.Row="1" ColumnDefinitions="*,*" HorizontalOptions="FillAndExpand" ColumnSpacing="10" Padding="10">
+            <Button
+                Grid.Column="0"
+                BackgroundColor="#3ece8e"
+                Command="{Binding AddBookCommand}"
+                Text="Add Book"
+                TextColor="#eff5f3" />
+            <Button
+                Grid.Column="1"
+                BackgroundColor="Red"
+                Command="{Binding CancelCommand}"
+                Text="Cancel"
+                TextColor="#eff5f3" />
+        </Grid>
+    </Grid>
 </ContentPage>

--- a/Views/Books/BooksListingPage.xaml
+++ b/Views/Books/BooksListingPage.xaml
@@ -13,7 +13,7 @@
         Margin="20"
         RowDefinitions="Auto,*"
         RowSpacing="10">
-        <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="20">
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="20">
             <Label
                 Grid.Column="0"
                 FontAttributes="Bold"
@@ -25,14 +25,6 @@
                 Command="{Binding AddBookCommand}"
                 HorizontalOptions="End"
                 Text="Add"
-                TextColor="#eff5f3" />
-            <Button
-                
-                Grid.Column="2"
-                Background="#3ece8e"
-                Command="{Binding GetBooksCommand}"
-                HorizontalOptions="End"
-                Text="show"
                 TextColor="#eff5f3" />
         </Grid>
 


### PR DESCRIPTION
### Description  
This merge request addresses the issue where the fields \(BookTitle, BookAuthor, BookIsFinished, and ImageUrl\) in the AddBookViewModel are not reset when navigating to the view to add a new book. This ensures that the fields are cleared before entering the view, providing a clean state for adding a new book.

### Changes Made  
- Added OnNavigatedTo method in AddBookViewModel to reset the fields.
- Modified the page's code-behind to call OnNavigatedTo in the OnAppearing method.
- Updated the AddBookPage.xaml to place the "Add Book" and "Cancel" buttons fixed at the bottom.
- Set the image preview to fit the screen width or its original size if it is smaller.

### Related Issues  
- Fixes issue where fields are not reset when adding a new book.

### Additional Notes  
This change impacts the AddBookViewModel and the corresponding page's code-behind. Ensure that the OnAppearing method in the page's code-behind correctly calls the OnNavigatedTo method of the view model.